### PR TITLE
Add script to retrieve OpenShift details

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML
+jsonpath-ng

--- a/retrieve_openshift_details.py
+++ b/retrieve_openshift_details.py
@@ -1,0 +1,32 @@
+import json
+import subprocess
+import sys
+
+def get_resource_details(resource_type, namespace):
+    command = [
+        "oc", "get", resource_type, "-n", namespace,
+        "-o=jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{.spec.template.spec.containers[*].resources}{\"\\n\"}{.status.replicas}{\"\\n\"}{end}"
+    ]
+    result = subprocess.run(command, capture_output=True, text=True)
+    return result.stdout.strip().split("\n")
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: python retrieve_openshift_details.py <namespace> <output_file>")
+        sys.exit(1)
+
+    namespace = sys.argv[1]
+    output_file = sys.argv[2]
+
+    details = {
+        "deployments": get_resource_details("deployments", namespace),
+        "deploymentconfigs": get_resource_details("deploymentconfigs", namespace),
+        "statefulsets": get_resource_details("statefulsets", namespace),
+        "daemonsets": get_resource_details("daemonsets", namespace)
+    }
+
+    with open(output_file, "w") as f:
+        json.dump(details, f, indent=4)
+
+if __name__ == "__main__":
+    main()

--- a/retrieve_openshift_details.sh
+++ b/retrieve_openshift_details.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+NAMESPACE=$1
+
+if [ -z "$NAMESPACE" ]; then
+  echo "Usage: $0 <namespace>"
+  exit 1
+fi
+
+output_file="openshift_details.json"
+
+echo "{" > $output_file
+
+echo "\"deployments\": [" >> $output_file
+echo "Retrieving deployment details..."
+oc get deployments -n $NAMESPACE -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{.spec.template.spec.containers[*].resources}{"\n"}{.status.replicas}{"\n"}{end}' >> $output_file
+echo "]," >> $output_file
+
+echo "\"deploymentconfigs\": [" >> $output_file
+echo "Retrieving deploymentconfig details..."
+oc get deploymentconfigs -n $NAMESPACE -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{.spec.template.spec.containers[*].resources}{"\n"}{.status.replicas}{"\n"}{end}' >> $output_file
+echo "]," >> $output_file
+
+echo "\"statefulsets\": [" >> $output_file
+echo "Retrieving statefulset details..."
+oc get statefulsets -n $NAMESPACE -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{.spec.template.spec.containers[*].resources}{"\n"}{.status.replicas}{"\n"}{end}' >> $output_file
+echo "]," >> $output_file
+
+echo "\"daemonsets\": [" >> $output_file
+echo "Retrieving daemonset details..."
+oc get daemonsets -n $NAMESPACE -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{.spec.template.spec.containers[*].resources}{"\n"}{end}' >> $output_file
+echo "]" >> $output_file
+
+echo "}" >> $output_file


### PR DESCRIPTION
Add a Python script to retrieve OpenShift namespace details and save them to a JSON file.

* Add `retrieve_openshift_details.py` to retrieve deployment, deploymentconfig, statefulset, and daemonset details.
* Add `requirements.txt` with `PyYAML` and `jsonpath-ng` dependencies.
* Add `retrieve_openshift_details.sh` as an initial bash script for retrieving OpenShift details.

