### PR TITLE
Convert CPU and memory values to millicores and MiB

### DIFF
--- a/retrieve_openshift_details.py
+++ b/retrieve_openshift_details.py
@@ -3,6 +3,20 @@ import subprocess
 import sys
 import csv
 
+def convert_cpu_to_millicores(cpu_value):
+    if cpu_value.endswith("m"):
+        return int(cpu_value[:-1])
+    return int(float(cpu_value) * 1000)
+
+def convert_memory_to_mib(memory_value):
+    if memory_value.endswith("Mi"):
+        return int(memory_value[:-2])
+    elif memory_value.endswith("Gi"):
+        return int(float(memory_value[:-2]) * 1024)
+    elif memory_value.endswith("Ki"):
+        return int(float(memory_value[:-2]) / 1024)
+    return int(memory_value)
+
 def get_resource_details(resource_type, namespace):
     command = [
         "oc", "get", resource_type, "-n", namespace,
@@ -19,10 +33,10 @@ def get_resource_details(resource_type, namespace):
             "name": details[i] if i < len(details) else "NotSet",
             "namespace": details[i+1] if i+1 < len(details) else "NotSet",
             "type": details[i+2] if i+2 < len(details) else "NotSet",
-            "limits.cpu": details[i+3] if i+3 < len(details) else "NotSet",
-            "limits.memory": details[i+4] if i+4 < len(details) else "NotSet",
-            "requests.cpu": details[i+5] if i+5 < len(details) else "NotSet",
-            "requests.memory": details[i+6] if i+6 < len(details) else "NotSet",
+            "limits.cpu": convert_cpu_to_millicores(details[i+3]) if i+3 < len(details) else "NotSet",
+            "limits.memory": convert_memory_to_mib(details[i+4]) if i+4 < len(details) else "NotSet",
+            "requests.cpu": convert_cpu_to_millicores(details[i+5]) if i+5 < len(details) else "NotSet",
+            "requests.memory": convert_memory_to_mib(details[i+6]) if i+6 < len(details) else "NotSet",
             "readiness_probe_time": details[i+7] if i+7 < len(details) else "NotSet",
             "current_replicas": details[i+8] if i+8 < len(details) else "NotSet",
             "min_replicas": details[i+9] if i+9 < len(details) else "NotSet",


### PR DESCRIPTION
Add unit conversion for CPU and memory values in `retrieve_openshift_details.py`.

* Add `convert_cpu_to_millicores` function to convert CPU values to millicores.
* Add `convert_memory_to_mib` function to convert memory values to MiB.
* Update `get_resource_details` function to use `convert_cpu_to_millicores` and `convert_memory_to_mib`.
* Update `write_csv` function to write CPU values in millicores and memory values in MiB.
* Update JSON output in the `main` function to contain CPU values in millicores and memory values in MiB.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davidecelano/openshift-utils/pull/6?shareId=b3a1bc14-d7fa-4cde-8ebe-68cc971cedda).